### PR TITLE
NoSuchMethodError ConcurrentHashMap.keySet in DockerContainers.unregisteredAfterTimeout

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/DockerContainers.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/DockerContainers.java
@@ -44,11 +44,9 @@ public class DockerContainers implements AgentInstances<DockerContainer> {
     public DockerContainer create(CreateAgentRequest request, PluginSettings settings) throws Exception {
         final Integer maxAllowedContainers = settings.getMaxDockerContainers();
         synchronized (instances) {
-
             doWithLockOnSemaphore(new SetupSemaphore(maxAllowedContainers, instances, semaphore));
 
             if (semaphore.tryAcquire()) {
-                LOG.debug("Number of container currently running not at the maximum ("+maxAllowedContainers+"). " + semaphore.availablePermits() + " containers could be started if necessary");
                 DockerContainer container = DockerContainer.create(request, settings, docker(settings));
                 register(container);
                 return container;

--- a/src/main/java/cd/go/contrib/elasticagents/docker/DockerContainers.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/DockerContainers.java
@@ -26,6 +26,7 @@ import org.joda.time.Period;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 
@@ -33,7 +34,7 @@ import static cd.go.contrib.elasticagents.docker.DockerPlugin.LOG;
 
 public class DockerContainers implements AgentInstances<DockerContainer> {
 
-    private final ConcurrentHashMap<String, DockerContainer> instances = new ConcurrentHashMap<>();
+    private final Map<String, DockerContainer> instances = new ConcurrentHashMap<>();
     private boolean refreshed;
     public Clock clock = Clock.DEFAULT;
 
@@ -43,9 +44,11 @@ public class DockerContainers implements AgentInstances<DockerContainer> {
     public DockerContainer create(CreateAgentRequest request, PluginSettings settings) throws Exception {
         final Integer maxAllowedContainers = settings.getMaxDockerContainers();
         synchronized (instances) {
+
             doWithLockOnSemaphore(new SetupSemaphore(maxAllowedContainers, instances, semaphore));
 
             if (semaphore.tryAcquire()) {
+                LOG.debug("Number of container currently running not at the maximum ("+maxAllowedContainers+"). " + semaphore.availablePermits() + " containers could be started if necessary");
                 DockerContainer container = DockerContainer.create(request, settings, docker(settings));
                 register(container);
                 return container;


### PR DESCRIPTION
I see a lot of errors when gocd unregister agents:

`
goserver        | LOG: java.lang.RuntimeException: Interaction with plugin with id 'cd.go.contrib.elastic-agent.docker' implementing 'elastic-agent' extension failed while requesting for 'go.cd.elastic-agent.server-ping'. Reason: [java.util.concurrent.ConcurrentHashMap.keySet()Ljava/util/concurrent/ConcurrentHashMap$KeySetView;]
goserver        | LOG:  at com.thoughtworks.go.plugin.access.PluginRequestHelper.submitRequest(PluginRequestHelper.java:41)
goserver        | LOG:  at com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension.serverPing(ElasticAgentExtension.java:60)
goserver        | LOG:  at com.thoughtworks.go.plugin.access.elastic.ElasticAgentPluginRegistry.serverPing(ElasticAgentPluginRegistry.java:83)
goserver        | LOG:  at com.thoughtworks.go.server.messaging.elasticagents.ServerPingListener.onMessage(ServerPingListener.java:32)
goserver        | LOG:  at com.thoughtworks.go.server.messaging.elasticagents.ServerPingListener.onMessage(ServerPingListener.java:22)
goserver        | LOG:  at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.runImpl(JMSMessageListenerAdapter.java:69)
goserver        | LOG:  at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.run(JMSMessageListenerAdapter.java:50)
goserver        | LOG:  at java.lang.Thread.run(Thread.java:745)
goserver        | LOG: Caused by: java.lang.RuntimeException: java.util.concurrent.ConcurrentHashMap.keySet()Ljava/util/concurrent/ConcurrentHashMap$KeySetView;
goserver        | LOG:  at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.executeActionOnTheService(FelixGoPluginOSGiFramework.java:317)
goserver        | LOG:  at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.doOn(FelixGoPluginOSGiFramework.java:245)
goserver        | LOG:  at com.thoughtworks.go.plugin.infra.DefaultPluginManager.submitTo(DefaultPluginManager.java:185)
goserver        | LOG:  at com.thoughtworks.go.plugin.access.PluginRequestHelper.submitRequest(PluginRequestHelper.java:32)
goserver        | LOG:  ... 7 more
goserver        | LOG: Caused by: java.lang.NoSuchMethodError: java.util.concurrent.ConcurrentHashMap.keySet()Ljava/util/concurrent/ConcurrentHashMap$KeySetView;
goserver        | LOG:  at cd.go.contrib.elasticagents.docker.DockerContainers.unregisteredAfterTimeout(DockerContainers.java:141)
goserver        | LOG:  at cd.go.contrib.elasticagents.docker.DockerContainers.terminateUnregisteredInstances(DockerContainers.java:90)
goserver        | LOG:  at cd.go.contrib.elasticagents.docker.executors.ServerPingRequestExecutor.execute(ServerPingRequestExecutor.java:59)
goserver        | LOG:  at cd.go.contrib.elasticagents.docker.DockerPlugin.handle(DockerPlugin.java:61)
goserver        | LOG:  at com.thoughtworks.go.plugin.infra.DefaultPluginManager$2.execute(DefaultPluginManager.java:190)
goserver        | LOG:  at com.thoughtworks.go.plugin.infra.DefaultPluginManager$2.execute(DefaultPluginManager.java:185)
goserver        | LOG:  at com.thoughtworks.go.plugin.infra.FelixGoPluginOSGiFramework.executeActionOnTheService(FelixGoPluginOSGiFramework.java:315)
goserver        | LOG:  ... 10 more
`


As explained in [this stackoverflow post](http://stackoverflow.com/questions/32954041/concurrenthashmap-crashing-application-compiled-with-jdk-8-but-targeting-jre-7), this is due to running gocd with jre7 with code compiled with Jdk 8. ConcurrentHashMap.KeySet did not exists on jre7. Typing variable with Map instead solve that
