### PR TITLE
Remove JobID information from agent status report page

### DIFF
--- a/src/main/resources/agent-status-report.template.ftlh
+++ b/src/main/resources/agent-status-report.template.ftlh
@@ -213,8 +213,7 @@
                 <a
                         href="/go/tab/build/detail/${jobIdentifier.representation!''}"
                         title="View this job's details"
-                        rel="nofollow noreferrer" target="_blank">${jobIdentifier.jobName!''}(${jobIdentifier.jobId!''}
-                    )</a>
+                        rel="nofollow noreferrer" target="_blank">${jobIdentifier.jobName!''}</a>
             </li>
 
             <li class="last">


### PR DESCRIPTION
* Fixes: https://github.com/gocd/gocd/issues/4486