### PR TITLE
Add a warning to server health messages if the max permissible limit for containers has been exceeded.

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/AgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/AgentInstances.java
@@ -31,9 +31,9 @@ public interface AgentInstances<T> {
      * <code>autoregister.properties</code> file.
      *
      * @param request   the request object
-     * @param settings  the plugin settings object
+     * @param pluginRequest  the plugin request object
      */
-    T create(CreateAgentRequest request, PluginSettings settings) throws Exception;
+    T create(CreateAgentRequest request, PluginRequest pluginRequest) throws Exception;
 
     /**
      * This message is sent when the plugin needs to terminate the agent instance.

--- a/src/main/java/cd/go/contrib/elasticagents/docker/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/Constants.java
@@ -40,6 +40,7 @@ public interface Constants {
     String REQUEST_SERVER_DELETE_AGENT = REQUEST_SERVER_PREFIX + ".elastic-agents.delete-agents";
     String REQUEST_SERVER_GET_PLUGIN_SETTINGS = REQUEST_SERVER_PREFIX + ".plugin-settings.get";
     String REQUEST_SERVER_LIST_AGENTS = REQUEST_SERVER_PREFIX + ".elastic-agents.list-agents";
+    String REQUEST_SERVER_SERVER_HEALTH_ADD_MESSAGES = REQUEST_SERVER_PREFIX + ".server-health.add-messages";
 
     // internal use only
     String CREATED_BY_LABEL_KEY = "Elastic-Agent-Created-By";

--- a/src/main/java/cd/go/contrib/elasticagents/docker/PluginRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/PluginRequest.java
@@ -16,12 +16,14 @@
 
 package cd.go.contrib.elasticagents.docker;
 
+import com.google.gson.Gson;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 
-import java.util.Collection;
+import java.util.*;
 
+import static cd.go.contrib.elasticagents.docker.DockerPlugin.LOG;
 import static cd.go.contrib.elasticagents.docker.Constants.PROCESSOR_API_VERSION;
 import static cd.go.contrib.elasticagents.docker.Constants.PLUGIN_IDENTIFIER;
 
@@ -84,6 +86,22 @@ public class PluginRequest {
 
         if (response.responseCode() != 200) {
             throw ServerRequestFailedException.deleteAgents(response);
+        }
+    }
+
+    public void addServerHealthMessage(List<Map<String, String>> messages) {
+        Gson gson = new Gson();
+
+        DefaultGoApiRequest request = new DefaultGoApiRequest(Constants.REQUEST_SERVER_SERVER_HEALTH_ADD_MESSAGES, PROCESSOR_API_VERSION, PLUGIN_IDENTIFIER);
+
+        request.setRequestBody(gson.toJson(messages));
+
+        // submit the request
+        GoApiResponse response = accessor.submit(request);
+
+        // check status
+        if (response.responseCode() != 200) {
+            LOG.error("The server sent an unexpected status code " + response.responseCode() + " with the response body " + response.responseBody());
         }
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutor.java
@@ -37,7 +37,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
 
     @Override
     public GoPluginApiResponse execute() throws Exception {
-        agentInstances.create(request, pluginRequest.getPluginSettings());
+        agentInstances.create(request, pluginRequest);
         return new DefaultGoPluginApiResponse(200);
     }
 

--- a/src/test/java/cd/go/contrib/elasticagents/docker/DockerContainersTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/DockerContainersTest.java
@@ -189,7 +189,7 @@ public class DockerContainersTest extends BaseTest {
         ArrayList<Map<String, String>> messages = new ArrayList<>();
         Map<String, String> message = new HashMap<>();
         message.put("type", "warning");
-        message.put("message", "The number of containers currently running is currently at the maximum permissible limit (0). Not creating more containers for jobs: up42/2/stage/1/job, up42/2/stage/1/job2.");
+        message.put("message", "The number of containers currently running is currently at the maximum permissible limit, \"0\". Not creating more containers for jobs: up42/2/stage/1/job, up42/2/stage/1/job2.");
         messages.add(message);
         verify(pluginRequest).addServerHealthMessage(messages);
     }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/DockerContainersTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/DockerContainersTest.java
@@ -184,12 +184,12 @@ public class DockerContainersTest extends BaseTest {
         PluginRequest pluginRequest = mock(PluginRequest.class);
         when(pluginRequest.getPluginSettings()).thenReturn(settings);
 
-        DockerContainer dockerContainer = dockerContainers.create(request, pluginRequest);
-
+        dockerContainers.create(request, pluginRequest);
+        dockerContainers.create(new CreateAgentRequest("key", new HashMap<>(), "production", new JobIdentifier("up42", 2L, "foo", "stage", "1", "job2", 1L)), pluginRequest);
         ArrayList<Map<String, String>> messages = new ArrayList<>();
         Map<String, String> message = new HashMap<>();
         message.put("type", "warning");
-        message.put("message", "The number of containers currently running is currently at the maximum permissible limit (0). Not creating any more containers.");
+        message.put("message", "The number of containers currently running is currently at the maximum permissible limit (0). Not creating more containers for jobs: up42/2/stage/1/job, up42/2/stage/1/job2.");
         messages.add(message);
         verify(pluginRequest).addServerHealthMessage(messages);
     }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutorTest.java
@@ -32,6 +32,6 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.getPluginSettings()).thenReturn(settings);
         new CreateAgentRequestExecutor(request, agentInstances, pluginRequest).execute();
 
-        verify(agentInstances).create(request, settings);
+        verify(agentInstances).create(request, pluginRequest);
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ServerPingRequestExecutorTest.java
@@ -84,7 +84,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("Image", "alpine");
         properties.put("Command", "/bin/sleep\n5");
-        DockerContainer container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier()), createSettings());
+        DockerContainer container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier()), pluginRequest);
         containers.add(container.name());
 
         ServerPingRequestExecutor serverPingRequestExecutor = new ServerPingRequestExecutor(agentInstances, pluginRequest);

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -16,10 +16,7 @@
 
 package cd.go.contrib.elasticagents.docker.executors;
 
-import cd.go.contrib.elasticagents.docker.Agent;
-import cd.go.contrib.elasticagents.docker.BaseTest;
-import cd.go.contrib.elasticagents.docker.DockerContainer;
-import cd.go.contrib.elasticagents.docker.DockerContainers;
+import cd.go.contrib.elasticagents.docker.*;
 import cd.go.contrib.elasticagents.docker.models.JobIdentifier;
 import cd.go.contrib.elasticagents.docker.requests.CreateAgentRequest;
 import cd.go.contrib.elasticagents.docker.requests.ShouldAssignWorkRequest;
@@ -33,6 +30,8 @@ import java.util.UUID;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
 
@@ -48,7 +47,10 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         properties.put("foo", "bar");
         properties.put("Image", "alpine");
         properties.put("Command", "/bin/sleep\n5");
-        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, jobIdentifier), createSettings());
+        PluginSettings settings = createSettings();
+        PluginRequest pluginRequest = mock(PluginRequest.class);
+        when(pluginRequest.getPluginSettings()).thenReturn(settings);
+        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, jobIdentifier), pluginRequest);
         containers.add(instance.name());
     }
 


### PR DESCRIPTION
* Clear the warning when the plugin can create new docker containers.

<img width="1200" alt="screen shot 2018-06-12 at 7 23 45 pm" src="https://user-images.githubusercontent.com/4715748/41295355-03ca8626-6e78-11e8-9e3c-91fc465c7bd4.png">


@arvindsv - is this alright? 