### PR TITLE
Add option to pull docker image on container create

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/DockerContainer.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/DockerContainer.java
@@ -103,6 +103,10 @@ public class DockerContainer {
 
         try {
             docker.inspectImage(imageName);
+            if (settings.pullOnContainerCreate()) {
+                LOG.info("Pulling a fresh version of " + imageName + ".");
+                docker.pull(imageName);
+            }
         } catch (ImageNotFoundException ex) {
             LOG.info("Image " + imageName + " not found, attempting to download.");
             docker.pull(imageName);

--- a/src/main/java/cd/go/contrib/elasticagents/docker/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/PluginSettings.java
@@ -80,6 +80,10 @@ public class PluginSettings {
     @SerializedName("enable_private_registry_authentication")
     private boolean useDockerAuthInfo;
 
+    @Expose
+    @SerializedName("pull_on_container_create")
+    private boolean pullOnContainerCreate;
+
     private Period autoRegisterPeriod;
 
     public static PluginSettings fromJSON(String json) {
@@ -111,6 +115,7 @@ public class PluginSettings {
             return false;
         if(privateRegistryPassword != null ? !privateRegistryPassword.equals(that.privateRegistryPassword) : that.privateRegistryPassword != null)
             return false;
+        if (pullOnContainerCreate != that.pullOnContainerCreate) return false;
         return autoRegisterPeriod != null ? autoRegisterPeriod.equals(that.autoRegisterPeriod) : that.autoRegisterPeriod == null;
     }
 
@@ -128,6 +133,7 @@ public class PluginSettings {
         result = 31 * result + (privateRegistryServer != null ? privateRegistryServer.hashCode() : 0);
         result = 31 * result + (privateRegistryPassword != null ? privateRegistryPassword.hashCode() : 0);
         result = 31 * result + (privateRegistryUsername != null ? privateRegistryUsername.hashCode() : 0);
+        result = 31 * result + (pullOnContainerCreate? 1 : 0);
         return result;
     }
 
@@ -189,6 +195,10 @@ public class PluginSettings {
         return Boolean.valueOf(useDockerAuthInfo);
     }
 
+    public Boolean pullOnContainerCreate() {
+        return Boolean.valueOf(pullOnContainerCreate);
+    }
+
     public void setDockerCACert(String dockerCACert) {
         this.dockerCACert = dockerCACert;
     }
@@ -211,5 +221,9 @@ public class PluginSettings {
 
     public void setMaxDockerContainers(Integer maxDockerContainers) {
         this.maxDockerContainers = String.valueOf(maxDockerContainers);
+    }
+
+    public void setPullOnContainerCreate(Boolean pullOnContainerCreate) {
+        this.pullOnContainerCreate = Boolean.valueOf(pullOnContainerCreate);
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetPluginConfigurationExecutor.java
@@ -46,7 +46,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field PRIVATE_REGISTRY_SERVER = new ConditionalNonBlankField("private_registry_server", "Private Registry Server", null, false, false, "9", privateRegistryFieldsPredicate);
     public static final Field PRIVATE_REGISTRY_USERNAME = new ConditionalNonBlankField("private_registry_username", "Private Registry Username", null, false, false, "10", privateRegistryFieldsPredicate);
     public static final Field PRIVATE_REGISTRY_PASSWORD = new ConditionalNonBlankField("private_registry_password", "Private Registry Password", null, false, true, "11", privateRegistryFieldsPredicate);
-
+    public static final Field PULL_ON_CONTAINER_CREATE = new NonBlankField("pull_on_container_create", "Pull image before creating the container", "false", true, false, "12");
 
     public static final Map<String, Field> FIELDS = new LinkedHashMap<>();
 
@@ -66,6 +66,8 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
         FIELDS.put(PRIVATE_REGISTRY_SERVER.key(), PRIVATE_REGISTRY_SERVER);
         FIELDS.put(PRIVATE_REGISTRY_USERNAME.key(), PRIVATE_REGISTRY_USERNAME);
         FIELDS.put(PRIVATE_REGISTRY_PASSWORD.key(), PRIVATE_REGISTRY_PASSWORD);
+
+        FIELDS.put(PULL_ON_CONTAINER_CREATE.key(), PULL_ON_CONTAINER_CREATE);
     }
 
     public GoPluginApiResponse execute() {

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -85,4 +85,12 @@
     <input type="password" ng-model="private_registry_password" ng-required="true"/>
     <span class="form_error" ng-show="GOINPUTNAME[private_registry_password].$error.server">{{GOINPUTNAME[private_registry_password].$error.server}}</span>
   </div>
+
+<div class="form_item_block" ng-int="pull_on_container_create = (pull_on_container_create || false)">
+  <label>Pull image before creating the container</label>
+  <input type="radio" ng-model="pull_on_container_create" value="true"/> True
+  <input type="radio" ng-model="pull_on_container_create" value="false"/> False
+  <span class="form_error" ng-show="GOINPUTNAME[pull_on_container_create].$error.server">{{GOINPUTNAME[pull_on_container_create].$error.server}}</span>
+</div>
+
 </div>

--- a/src/test/java/cd/go/contrib/elasticagents/docker/DockerContainerTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/DockerContainerTest.java
@@ -225,4 +225,18 @@ public class DockerContainerTest extends BaseTest {
         assertThat(environmentVariables, hasEntry("A", "B"));
         assertThat(environmentVariables, hasEntry("C", "D"));
     }
+
+    @Test
+    public void shouldPullImageWhenPullSettingIsEnabled() throws Exception {
+        String imageName = "busybox:latest";
+        PluginSettings settings = createSettings();
+        settings.setPullOnContainerCreate(true);
+
+        DockerContainer container = DockerContainer.create(new CreateAgentRequest("key", Collections.singletonMap("Image", imageName), "prod", jobIdentifier), settings, docker);
+        assertContainerExist(container.name());
+        containers.add(container.name());
+
+        assertNotNull(docker.inspectImage(imageName));
+        assertContainerExist(container.name());
+    }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/GetPluginConfigurationExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/GetPluginConfigurationExecutorTest.java
@@ -119,6 +119,13 @@ public class GetPluginConfigurationExecutorTest {
                 "    \"required\": false,\n" +
                 "    \"secure\": true,\n" +
                 "    \"display-order\": \"11\"\n" +
+                "  }," +
+                "  \"pull_on_container_create\": {\n" +
+                "    \"display-name\": \"Pull image before creating the container\",\n" +
+                "    \"default-value\": \"false\",\n" +
+                "    \"required\": true,\n" +
+                "    \"secure\": false,\n" +
+                "    \"display-order\": \"12\"\n" +
                 "  }" +
                 "}\n";
         JSONAssert.assertEquals(expectedJSON, response.responseBody(), true);

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ValidateConfigurationExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ValidateConfigurationExecutorTest.java
@@ -51,7 +51,11 @@ public class ValidateConfigurationExecutorTest {
                 "  {\n" +
                 "    \"message\": \"Use Private Registry must not be blank.\",\n" +
                 "    \"key\": \"enable_private_registry_authentication\"\n" +
-                "  }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"message\": \"Pull image before creating the container must not be blank.\",\n" +
+                "    \"key\": \"pull_on_container_create\"\n" +
+                "  },\n" +
                 "]\n", response.responseBody(), true);
     }
 
@@ -66,6 +70,7 @@ public class ValidateConfigurationExecutorTest {
         settings.put("go_server_url", "https://ci.example.com/go");
         settings.put("enable_private_registry_authentication", "false");
         settings.put("auto_register_timeout", "10");
+        settings.put("pull_on_container_create", "false");
 
         GoPluginApiResponse response = new ValidateConfigurationExecutor(settings).execute();
 
@@ -88,6 +93,7 @@ public class ValidateConfigurationExecutorTest {
         settings.put("private_registry_username", "username");
         settings.put("private_registry_password", "password");
         settings.put("auto_register_timeout", "10");
+        settings.put("pull_on_container_create", "false");
         GoPluginApiResponse response = new ValidateConfigurationExecutor(settings).execute();
 
         assertThat(response.responseCode(), is(200));
@@ -108,6 +114,7 @@ public class ValidateConfigurationExecutorTest {
         settings.put("private_registry_username", "");
         settings.put("private_registry_password", "");
         settings.put("auto_register_timeout", "10");
+        settings.put("pull_on_container_create", "false");
         GoPluginApiResponse response = new ValidateConfigurationExecutor(settings).execute();
 
         String expectedString = "[{\"message\":\"Private Registry Server must not be blank.\",\"key\":\"private_registry_server\"}," +


### PR DESCRIPTION
This adds a checkbox to the plugin configuration which enables pulling the image before running a task. It's useful for the case when you're using the `latest` tag for your task containers and want to make sure you're using the correct agent image.