### PR TITLE
Make enable_private_registry_authentication and pull_on_container_create optional with defaults. (#73)

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetPluginConfigurationExecutor.java
@@ -39,14 +39,14 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field DOCKER_CA_CERT = new Field("docker_ca_cert", "Docker CA Certificate", null, false, true, "5");
     public static final Field DOCKER_CLIENT_KEY = new Field("docker_client_key", "Docker Client Key", null, false, true, "6");
     public static final Field DOCKER_CLIENT_CERT = new Field("docker_client_cert", "Docker Client Certificate", null, false, true, "7");
-    public static final Field ENABLE_PRIVATE_REGISTRY_AUTHENTICATION = new NonBlankField("enable_private_registry_authentication", "Use Private Registry", "false", true, false, "8");
+    public static final Field ENABLE_PRIVATE_REGISTRY_AUTHENTICATION = new Field("enable_private_registry_authentication", "Use Private Registry", "false", true, false, "8");
     private static final Predicate<ValidatePluginSettings> privateRegistryFieldsPredicate = new Predicate<ValidatePluginSettings>() {
         @Override public boolean apply(ValidatePluginSettings settings) { return Boolean.parseBoolean(settings.get(ENABLE_PRIVATE_REGISTRY_AUTHENTICATION.key()));}
     };
     public static final Field PRIVATE_REGISTRY_SERVER = new ConditionalNonBlankField("private_registry_server", "Private Registry Server", null, false, false, "9", privateRegistryFieldsPredicate);
     public static final Field PRIVATE_REGISTRY_USERNAME = new ConditionalNonBlankField("private_registry_username", "Private Registry Username", null, false, false, "10", privateRegistryFieldsPredicate);
     public static final Field PRIVATE_REGISTRY_PASSWORD = new ConditionalNonBlankField("private_registry_password", "Private Registry Password", null, false, true, "11", privateRegistryFieldsPredicate);
-    public static final Field PULL_ON_CONTAINER_CREATE = new NonBlankField("pull_on_container_create", "Pull image before creating the container", "false", true, false, "12");
+    public static final Field PULL_ON_CONTAINER_CREATE = new Field("pull_on_container_create", "Pull image before creating the container", "false", true, false, "12");
 
     public static final Map<String, Field> FIELDS = new LinkedHashMap<>();
 

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ValidateConfigurationExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ValidateConfigurationExecutorTest.java
@@ -47,14 +47,6 @@ public class ValidateConfigurationExecutorTest {
                 "  {\n" +
                 "    \"message\": \"Agent auto-register Timeout (in minutes) must be a positive integer.\",\n" +
                 "    \"key\": \"auto_register_timeout\"\n" +
-                "  },\n" +
-                "  {\n" +
-                "    \"message\": \"Use Private Registry must not be blank.\",\n" +
-                "    \"key\": \"enable_private_registry_authentication\"\n" +
-                "  },\n" +
-                "  {\n" +
-                "    \"message\": \"Pull image before creating the container must not be blank.\",\n" +
-                "    \"key\": \"pull_on_container_create\"\n" +
                 "  }\n" +
                 "]\n", response.responseBody(), true);
     }


### PR DESCRIPTION
* These settings are checkboxes in the plugin settings view which users can optionally check/uncheck.

