### PR TITLE
Updated get-agent-status-report to utilize cluster settings instead of plugin settings

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/DockerPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/DockerPlugin.java
@@ -95,9 +95,10 @@ public class DockerPlugin implements GoPlugin {
 //                    refreshInstances();
 //                    return new StatusReportExecutor(pluginRequest, agentInstances, ViewBuilder.instance()).execute();
                 case REQUEST_AGENT_STATUS_REPORT:
-                    return new DefaultGoPluginApiResponse(200);
-//                    refreshInstances();
-//                    return AgentStatusReportRequest.fromJSON(request.requestBody()).executor(pluginRequest, agentInstances).execute();
+                    AgentStatusReportRequest statusReportRequest = AgentStatusReportRequest.fromJSON(request.requestBody());
+                    ClusterProfileProperties clusterProfile = statusReportRequest.getClusterProfile();
+                    refreshInstancesForCluster(clusterProfile);
+                    return statusReportRequest.executor(pluginRequest, clusterSpecificAgentInstances.get(clusterProfile.uuid())).execute();
                 case REQUEST_CAPABILITIES:
                     return new GetCapabilitiesExecutor().execute();
                 case REQUEST_JOB_COMPLETION:

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/AgentStatusReportExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/AgentStatusReportExecutor.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang.StringUtils;
 import java.io.IOException;
 import java.util.Optional;
 
+import static java.lang.String.format;
+
 public class AgentStatusReportExecutor {
     private static final Logger LOG = Logger.getLoggerFor(AgentStatusReportExecutor.class);
     private final AgentStatusReportRequest request;
@@ -38,7 +40,7 @@ public class AgentStatusReportExecutor {
     public GoPluginApiResponse execute() throws Exception {
         String elasticAgentId = request.getElasticAgentId();
         JobIdentifier jobIdentifier = request.getJobIdentifier();
-        LOG.info(String.format("[status-report] Generating status report for agent: %s with job: %s", elasticAgentId, jobIdentifier));
+        LOG.info(format("[status-report] Generating status report for agent: %s with job: %s", elasticAgentId, jobIdentifier));
 
         try {
             if (StringUtils.isNotBlank(elasticAgentId)) {
@@ -56,7 +58,7 @@ public class AgentStatusReportExecutor {
     private GoPluginApiResponse getStatusReportUsingJobIdentifier(JobIdentifier jobIdentifier) throws Exception {
         Optional<DockerContainer> dockerContainer = dockerContainers.find(jobIdentifier);
         if (dockerContainer.isPresent()) {
-            AgentStatusReport agentStatusReport = dockerContainers.getAgentStatusReport(pluginRequest.getPluginSettings(), dockerContainer.get());
+            AgentStatusReport agentStatusReport = dockerContainers.getAgentStatusReport(request.getClusterProfile(), dockerContainer.get());
             final String statusReportView = viewBuilder.build(viewBuilder.getTemplate("agent-status-report.template.ftlh"), agentStatusReport);
             return constructResponseForReport(statusReportView);
         }
@@ -67,7 +69,7 @@ public class AgentStatusReportExecutor {
     private GoPluginApiResponse getStatusReportUsingElasticAgentId(String elasticAgentId) throws Exception {
         Optional<DockerContainer> dockerContainer = Optional.ofNullable(dockerContainers.find(elasticAgentId));
         if (dockerContainer.isPresent()) {
-            AgentStatusReport agentStatusReport = dockerContainers.getAgentStatusReport(pluginRequest.getPluginSettings(), dockerContainer.get());
+            AgentStatusReport agentStatusReport = dockerContainers.getAgentStatusReport(request.getClusterProfile(), dockerContainer.get());
             final String statusReportView = viewBuilder.build(viewBuilder.getTemplate("agent-status-report.template.ftlh"), agentStatusReport);
             return constructResponseForReport(statusReportView);
         }

--- a/src/main/java/cd/go/contrib/elasticagents/docker/requests/AgentStatusReportRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/requests/AgentStatusReportRequest.java
@@ -1,5 +1,6 @@
 package cd.go.contrib.elasticagents.docker.requests;
 
+import cd.go.contrib.elasticagents.docker.ClusterProfileProperties;
 import cd.go.contrib.elasticagents.docker.DockerContainers;
 import cd.go.contrib.elasticagents.docker.PluginRequest;
 import cd.go.contrib.elasticagents.docker.executors.AgentStatusReportExecutor;
@@ -9,8 +10,10 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 public class AgentStatusReportRequest {
@@ -24,12 +27,17 @@ public class AgentStatusReportRequest {
     @Expose
     private JobIdentifier jobIdentifier;
 
+    @Expose
+    @SerializedName("cluster_profile_properties")
+    private ClusterProfileProperties clusterProfile;
+
     public AgentStatusReportRequest() {
     }
 
-    public AgentStatusReportRequest(String elasticAgentId, JobIdentifier jobIdentifier) {
+    public AgentStatusReportRequest(String elasticAgentId, JobIdentifier jobIdentifier, Map<String, String> clusterProfileProperties) {
         this.elasticAgentId = elasticAgentId;
         this.jobIdentifier = jobIdentifier;
+        this.clusterProfile = ClusterProfileProperties.fromConfiguration(clusterProfileProperties);
     }
 
     public static AgentStatusReportRequest fromJSON(String json) {
@@ -48,18 +56,23 @@ public class AgentStatusReportRequest {
         return new AgentStatusReportExecutor(this, pluginRequest, dockerContainers, ViewBuilder.instance());
     }
 
+    public ClusterProfileProperties getClusterProfile() {
+        return clusterProfile;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AgentStatusReportRequest that = (AgentStatusReportRequest) o;
         return Objects.equals(elasticAgentId, that.elasticAgentId) &&
-                Objects.equals(jobIdentifier, that.jobIdentifier);
+                Objects.equals(jobIdentifier, that.jobIdentifier) &&
+                Objects.equals(clusterProfile, that.clusterProfile);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(elasticAgentId, jobIdentifier);
+        return Objects.hash(elasticAgentId, jobIdentifier, clusterProfile);
     }
 
     @Override
@@ -67,6 +80,7 @@ public class AgentStatusReportRequest {
         return "AgentStatusReportRequest{" +
                 "elasticAgentId='" + elasticAgentId + '\'' +
                 ", jobIdentifier=" + jobIdentifier +
+                ", clusterProfile=" + clusterProfile +
                 '}';
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/AgentStatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/AgentStatusReportExecutorTest.java
@@ -1,9 +1,9 @@
 package cd.go.contrib.elasticagents.docker.executors;
 
+import cd.go.contrib.elasticagents.docker.ClusterProfileProperties;
 import cd.go.contrib.elasticagents.docker.DockerContainer;
 import cd.go.contrib.elasticagents.docker.DockerContainers;
 import cd.go.contrib.elasticagents.docker.PluginRequest;
-import cd.go.contrib.elasticagents.docker.PluginSettings;
 import cd.go.contrib.elasticagents.docker.models.AgentStatusReport;
 import cd.go.contrib.elasticagents.docker.models.JobIdentifier;
 import cd.go.contrib.elasticagents.docker.models.NotRunningAgentStatusReport;
@@ -12,16 +12,14 @@ import cd.go.contrib.elasticagents.docker.views.ViewBuilder;
 import com.google.gson.JsonObject;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import freemarker.template.Template;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,23 +33,29 @@ public class AgentStatusReportExecutorTest {
     @Mock
     private PluginRequest pluginRequest;
     @Mock
-    private PluginSettings pluginSettings;
-    @Mock
     private DockerContainers dockerContainers;
     @Mock
     private ViewBuilder viewBuilder;
     @Mock
     private Template template;
+    private Map<String, String> clusterProfileConfigurations;
+    private ClusterProfileProperties clusterProfile;
+
+    @Before
+    public void setup() {
+        clusterProfileConfigurations = Collections.singletonMap("go_server_url", "http://go-server-url/go");
+        clusterProfile = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
+    }
 
     @Test
     public void shouldGetAgentStatusReportWithElasticAgentId() throws Exception {
         String agentId = "elastic-agent-id";
-        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(agentId, null);
+        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(agentId, null, clusterProfileConfigurations);
         AgentStatusReport agentStatusReport = new AgentStatusReport(null, agentId, null, null, null, null, null, new HashMap<>(), new ArrayList<>());
-        when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
+
         DockerContainer dockerContainer = new DockerContainer("id", "name", new JobIdentifier(), new Date(), new HashMap<>(), null);
         when(dockerContainers.find(agentId)).thenReturn(dockerContainer);
-        when(dockerContainers.getAgentStatusReport(pluginSettings, dockerContainer)).thenReturn(agentStatusReport);
+        when(dockerContainers.getAgentStatusReport(clusterProfile, dockerContainer)).thenReturn(agentStatusReport);
         when(viewBuilder.getTemplate("agent-status-report.template.ftlh")).thenReturn(template);
         when(viewBuilder.build(template, agentStatusReport)).thenReturn("agentStatusReportView");
 
@@ -67,12 +71,12 @@ public class AgentStatusReportExecutorTest {
     @Test
     public void shouldGetAgentStatusReportWithJobIdentifier() throws Exception {
         JobIdentifier jobIdentifier = new JobIdentifier("up42", 2L, "label", "stage1", "1", "job", 1L);
-        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(null, jobIdentifier);
+        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(null, jobIdentifier, clusterProfileConfigurations);
         AgentStatusReport agentStatusReport = new AgentStatusReport(jobIdentifier, "elastic-agent-id", null, null, null, null, null, new HashMap<>(), new ArrayList<>());
-        when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
+
         DockerContainer dockerContainer = new DockerContainer("id", "name", jobIdentifier, new Date(), new HashMap<>(), null);
         when(dockerContainers.find(jobIdentifier)).thenReturn(Optional.ofNullable(dockerContainer));
-        when(dockerContainers.getAgentStatusReport(pluginSettings, dockerContainer)).thenReturn(agentStatusReport);
+        when(dockerContainers.getAgentStatusReport(clusterProfile, dockerContainer)).thenReturn(agentStatusReport);
         when(viewBuilder.getTemplate("agent-status-report.template.ftlh")).thenReturn(template);
         when(viewBuilder.build(template, agentStatusReport)).thenReturn("agentStatusReportView");
 
@@ -89,7 +93,7 @@ public class AgentStatusReportExecutorTest {
     public void shouldRenderContainerNotFoundAgentStatusReportViewWhenNoContainerIsRunningForProvidedJobIdentifier() throws Exception {
         JobIdentifier jobIdentifier = new JobIdentifier("up42", 2L, "label", "stage1", "1", "job", 1L);
 
-        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(null, jobIdentifier);
+        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(null, jobIdentifier, clusterProfileConfigurations);
 
         when(dockerContainers.find(jobIdentifier)).thenReturn(Optional.empty());
         when(viewBuilder.getTemplate("not-running-agent-status-report.template.ftlh")).thenReturn(template);
@@ -107,14 +111,14 @@ public class AgentStatusReportExecutorTest {
     @Test
     public void shouldRenderContainerNotFoundAgentStatusReportViewWhenNoContainerIsRunningForProvidedElasticAgentId() throws Exception {
         String elasticAgentId = "elastic-agent-id";
-        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(elasticAgentId, null);
+        AgentStatusReportRequest agentStatusReportRequest = new AgentStatusReportRequest(elasticAgentId, null, clusterProfileConfigurations);
 
         when(dockerContainers.find(elasticAgentId)).thenReturn(null);
         when(viewBuilder.getTemplate("not-running-agent-status-report.template.ftlh")).thenReturn(template);
         when(viewBuilder.build(eq(template), any(NotRunningAgentStatusReport.class))).thenReturn("errorView");
 
         GoPluginApiResponse goPluginApiResponse = new AgentStatusReportExecutor(agentStatusReportRequest, pluginRequest, dockerContainers, viewBuilder)
-            .execute();
+                .execute();
 
         JsonObject expectedResponseBody = new JsonObject();
         expectedResponseBody.addProperty("view", "errorView");

--- a/src/test/java/cd/go/contrib/elasticagents/docker/requests/AgentStatusReportRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/requests/AgentStatusReportRequestTest.java
@@ -4,6 +4,9 @@ import cd.go.contrib.elasticagents.docker.utils.JobIdentifierMother;
 import com.google.gson.JsonObject;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -18,7 +21,28 @@ public class AgentStatusReportRequestTest {
 
         AgentStatusReportRequest agentStatusReportRequest = AgentStatusReportRequest.fromJSON(jsonObject.toString());
 
-        AgentStatusReportRequest expected = new AgentStatusReportRequest("some-id", JobIdentifierMother.get());
+        AgentStatusReportRequest expected = new AgentStatusReportRequest("some-id", JobIdentifierMother.get(), null);
+        assertThat(agentStatusReportRequest, is(expected));
+    }
+
+    @Test
+    public void shouldDeserializeFromJSONWithClusterProfile() {
+        JsonObject jobIdentifierJson = JobIdentifierMother.getJson();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("elastic_agent_id", "some-id");
+        jsonObject.add("job_identifier", jobIdentifierJson);
+        JsonObject clusterJSON = new JsonObject();
+        clusterJSON.addProperty("go_server_url", "https://foo.com/go");
+        clusterJSON.addProperty("docker_uri", "unix:///var/run/docker.sock");
+        jsonObject.add("cluster_profile_properties", clusterJSON);
+
+        AgentStatusReportRequest agentStatusReportRequest = AgentStatusReportRequest.fromJSON(jsonObject.toString());
+
+        Map<String, String> expectedClusterProfile = new HashMap<>();
+        expectedClusterProfile.put("go_server_url", "https://foo.com/go");
+        expectedClusterProfile.put("docker_uri", "unix:///var/run/docker.sock");
+
+        AgentStatusReportRequest expected = new AgentStatusReportRequest("some-id", JobIdentifierMother.get(), expectedClusterProfile);
         assertThat(agentStatusReportRequest, is(expected));
     }
 }


### PR DESCRIPTION
Link to the issue: https://github.com/gocd/gocd/issues/5937

Link to the related GoCD PR: https://github.com/gocd/gocd/pull/6054