### PR TITLE
Cluster-status-report implementation

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/DockerPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/DockerPlugin.java
@@ -105,6 +105,12 @@ public class DockerPlugin implements GoPlugin {
                     clusterProfileProperties = jobCompletionRequest.getClusterProfileProperties();
                     refreshInstancesForCluster(clusterProfileProperties);
                     return jobCompletionRequest.executor(getAgentInstancesFor(clusterProfileProperties), pluginRequest).execute();
+                case REQUEST_CLUSTER_STATUS_REPORT:
+                    ClusterStatusReportRequest clusterStatusReportRequest = ClusterStatusReportRequest.fromJSON(request.requestBody());
+                    clusterProfileProperties = clusterStatusReportRequest.getClusterProfile();
+                    refreshInstancesForCluster(clusterProfileProperties);
+                    return clusterStatusReportRequest.executor(clusterSpecificAgentInstances.get(clusterProfileProperties.uuid()))
+                            .execute();
                 default:
                     throw new UnhandledRequestTypeException(request.requestName());
             }

--- a/src/main/java/cd/go/contrib/elasticagents/docker/Request.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/Request.java
@@ -37,6 +37,7 @@ public enum Request {
     REQUEST_VALIDATE_CLUSTER_PROFILE_CONFIGURATION(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".validate-cluster-profile"),
     REQUEST_GET_CLUSTER_PROFILE_VIEW(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-cluster-profile-view"),
     REQUEST_STATUS_REPORT(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".status-report"),
+    REQUEST_CLUSTER_STATUS_REPORT(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".cluster-status-report"),
     REQUEST_AGENT_STATUS_REPORT(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".agent-status-report"),
     REQUEST_CAPABILITIES(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-capabilities"),
     REQUEST_JOB_COMPLETION(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".job-completion"),

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/ClusterStatusReportExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/ClusterStatusReportExecutor.java
@@ -1,9 +1,9 @@
 package cd.go.contrib.elasticagents.docker.executors;
 
 import cd.go.contrib.elasticagents.docker.DockerContainers;
-import cd.go.contrib.elasticagents.docker.PluginRequest;
 import cd.go.contrib.elasticagents.docker.RequestExecutor;
 import cd.go.contrib.elasticagents.docker.models.StatusReport;
+import cd.go.contrib.elasticagents.docker.requests.ClusterStatusReportRequest;
 import cd.go.contrib.elasticagents.docker.views.ViewBuilder;
 import com.google.gson.JsonObject;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
@@ -12,14 +12,14 @@ import freemarker.template.Template;
 
 import static cd.go.contrib.elasticagents.docker.DockerPlugin.LOG;
 
-public class StatusReportExecutor implements RequestExecutor {
+public class ClusterStatusReportExecutor implements RequestExecutor {
 
-    private final PluginRequest pluginRequest;
+    private final ClusterStatusReportRequest clusterStatusReportRequest;
     private final DockerContainers dockerContainers;
     private final ViewBuilder viewBuilder;
 
-    public StatusReportExecutor(PluginRequest pluginRequest, DockerContainers dockerContainers, ViewBuilder viewBuilder) {
-        this.pluginRequest = pluginRequest;
+    public ClusterStatusReportExecutor(ClusterStatusReportRequest clusterStatusReportRequest, DockerContainers dockerContainers, ViewBuilder viewBuilder) {
+        this.clusterStatusReportRequest = clusterStatusReportRequest;
         this.dockerContainers = dockerContainers;
         this.viewBuilder = viewBuilder;
     }
@@ -28,7 +28,7 @@ public class StatusReportExecutor implements RequestExecutor {
     public GoPluginApiResponse execute() throws Exception {
         LOG.info("[status-report] Generating status report");
 
-        StatusReport statusReport = dockerContainers.getStatusReport(pluginRequest.getPluginSettings());
+        StatusReport statusReport = dockerContainers.getStatusReport(clusterStatusReportRequest.getClusterProfile());
 
         final Template template = viewBuilder.getTemplate("status-report.template.ftlh");
         final String statusReportView = viewBuilder.build(template, statusReport);

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetCapabilitiesExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetCapabilitiesExecutor.java
@@ -16,8 +16,9 @@ public class GetCapabilitiesExecutor implements RequestExecutor {
     private static final Map<String, Boolean> CAPABILITIES_RESPONSE = new LinkedHashMap<>();
 
     static {
-        CAPABILITIES_RESPONSE.put("supports_status_report", true);
+        CAPABILITIES_RESPONSE.put("supports_plugin_status_report", false);
         CAPABILITIES_RESPONSE.put("supports_agent_status_report", true);
+        CAPABILITIES_RESPONSE.put("supports_cluster_status_report", true);
     }
 
     @Override

--- a/src/main/java/cd/go/contrib/elasticagents/docker/requests/ClusterStatusReportRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/requests/ClusterStatusReportRequest.java
@@ -1,0 +1,65 @@
+package cd.go.contrib.elasticagents.docker.requests;
+
+import cd.go.contrib.elasticagents.docker.ClusterProfile;
+import cd.go.contrib.elasticagents.docker.ClusterProfileProperties;
+import cd.go.contrib.elasticagents.docker.DockerContainers;
+import cd.go.contrib.elasticagents.docker.executors.ClusterStatusReportExecutor;
+import cd.go.contrib.elasticagents.docker.views.ViewBuilder;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class ClusterStatusReportRequest {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .create();
+
+    @Expose
+    @SerializedName("cluster_profile_properties")
+    private ClusterProfileProperties clusterProfile;
+
+    public ClusterStatusReportRequest() {
+    }
+
+    public ClusterStatusReportRequest(Map<String, String> clusterProfileConfigurations) {
+        this.clusterProfile = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
+    }
+
+    public ClusterProfileProperties getClusterProfile() {
+        return clusterProfile;
+    }
+
+    public static ClusterStatusReportRequest fromJSON(String json) {
+        return GSON.fromJson(json, ClusterStatusReportRequest.class);
+    }
+
+    public ClusterStatusReportExecutor executor(DockerContainers dockerContainers) throws IOException {
+        return new ClusterStatusReportExecutor(this, dockerContainers, ViewBuilder.instance());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClusterStatusReportRequest that = (ClusterStatusReportRequest) o;
+        return Objects.equals(clusterProfile, that.clusterProfile);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterProfile);
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterStatusReportRequest{" +
+                "clusterProfile=" + clusterProfile +
+                '}';
+    }
+}

--- a/src/main/resources/status-report.template.ftlh
+++ b/src/main/resources/status-report.template.ftlh
@@ -103,7 +103,7 @@
 <div data-plugin-style-id="docker-elastic-plugin">
 	<div class="container">
 		<div class="page_header">
-			<h1 class="page_title">Plugin Status Report</h1>
+			<h1 class="page_title">Cluster Status Report</h1>
 		</div>
 		<div class="docker row">
 			<div>

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ClusterStatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ClusterStatusReportExecutorTest.java
@@ -1,9 +1,9 @@
 package cd.go.contrib.elasticagents.docker.executors;
 
+import cd.go.contrib.elasticagents.docker.ClusterProfileProperties;
 import cd.go.contrib.elasticagents.docker.DockerContainers;
-import cd.go.contrib.elasticagents.docker.PluginRequest;
-import cd.go.contrib.elasticagents.docker.PluginSettings;
 import cd.go.contrib.elasticagents.docker.models.StatusReport;
+import cd.go.contrib.elasticagents.docker.requests.ClusterStatusReportRequest;
 import cd.go.contrib.elasticagents.docker.views.ViewBuilder;
 import com.google.gson.JsonObject;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
@@ -21,13 +21,13 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StatusReportExecutorTest {
+public class ClusterStatusReportExecutorTest {
 
     @Mock
-    private PluginRequest pluginRequest;
+    private ClusterStatusReportRequest clusterStatusReportRequest;
 
     @Mock
-    private PluginSettings pluginSettings;
+    private ClusterProfileProperties clusterProfile;
 
     @Mock
     private ViewBuilder viewBuilder;
@@ -41,11 +41,11 @@ public class StatusReportExecutorTest {
     @Test
     public void shouldGetStatusReport() throws Exception {
         StatusReport statusReport = aStatusReport();
-        when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(dockerContainers.getStatusReport(pluginSettings)).thenReturn(statusReport);
+        when(clusterStatusReportRequest.getClusterProfile()).thenReturn(clusterProfile);
+        when(dockerContainers.getStatusReport(clusterProfile)).thenReturn(statusReport);
         when(viewBuilder.getTemplate("status-report.template.ftlh")).thenReturn(template);
         when(viewBuilder.build(template, statusReport)).thenReturn("statusReportView");
-        StatusReportExecutor statusReportExecutor = new StatusReportExecutor(pluginRequest, dockerContainers, viewBuilder);
+        ClusterStatusReportExecutor statusReportExecutor = new ClusterStatusReportExecutor(clusterStatusReportRequest, dockerContainers, viewBuilder);
 
         GoPluginApiResponse goPluginApiResponse = statusReportExecutor.execute();
 

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/GetCapabilitiesExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/GetCapabilitiesExecutorTest.java
@@ -15,8 +15,9 @@ public class GetCapabilitiesExecutorTest {
         GoPluginApiResponse response = new GetCapabilitiesExecutor().execute();
 
         assertThat(response.responseCode(), is(200));
-        JSONObject expected = new JSONObject().put("supports_status_report", true);
+        JSONObject expected = new JSONObject().put("supports_plugin_status_report", false);
         expected.put("supports_agent_status_report", true);
+        expected.put("supports_cluster_status_report", true);
         JSONAssert.assertEquals(expected, new JSONObject(response.responseBody()), true);
     }
 

--- a/src/test/java/cd/go/contrib/elasticagents/docker/requests/ClusterStatusReportRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/requests/ClusterStatusReportRequestTest.java
@@ -1,0 +1,25 @@
+package cd.go.contrib.elasticagents.docker.requests;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ClusterStatusReportRequestTest {
+
+    @Test
+    public void shouldDeserializeFromJSON() {
+        JsonObject jsonObject = new JsonObject();
+        JsonObject clusterJSON = new JsonObject();
+        clusterJSON.addProperty("go_server_url", "https://go-server/go");
+        jsonObject.add("cluster_profile_properties", clusterJSON);
+
+        ClusterStatusReportRequest clusterStatusReportRequest = ClusterStatusReportRequest.fromJSON(jsonObject.toString());
+
+        ClusterStatusReportRequest expected = new ClusterStatusReportRequest(Collections.singletonMap("go_server_url", "https://go-server/go"));
+        assertThat(clusterStatusReportRequest, is(expected));
+    }
+}


### PR DESCRIPTION
Added get-cluster-status-report implementation.
Set support-plugin-status-report capability as false

Link to the issue: gocd/gocd#5937

Link to the related GoCD PR: https://github.com/gocd/gocd/pull/6057