### PR TITLE
Implement migrate config plugin api call

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/MigrateConfigurationRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/MigrateConfigurationRequestExecutor.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -39,34 +40,74 @@ public class MigrateConfigurationRequestExecutor implements RequestExecutor {
 
     @Override
     public GoPluginApiResponse execute() throws Exception {
+        LOG.info("[Migrate Config] Request for Config Migration Started...");
+
         PluginSettings pluginSettings = migrateConfigurationRequest.getPluginSettings();
         List<ClusterProfile> existingClusterProfiles = migrateConfigurationRequest.getClusterProfiles();
         List<ElasticAgentProfile> existingElasticAgentProfiles = migrateConfigurationRequest.getElasticAgentProfiles();
 
         if (!arePluginSettingsConfigured(pluginSettings)) {
-            LOG.info("[Migrate Config] No Plugin Settings are configured. Skipping Config Migration.");
+            LOG.info("[Migrate Config] No Plugin Settings are configured. Skipping Config Migration...");
             return new DefaultGoPluginApiResponse(200, migrateConfigurationRequest.toJSON());
         }
 
-        if (!existingClusterProfiles.isEmpty()) {
-            List<String> existingClusterProfileIds = existingClusterProfiles.stream().map(ClusterProfile::getId).collect(Collectors.toList());
-            LOG.info("[Migrate Config] Found already defined cluster profiles {}. Skipping Config Migration.", existingClusterProfileIds);
-            return new DefaultGoPluginApiResponse(200, migrateConfigurationRequest.toJSON());
+        if (existingClusterProfiles.size() == 0) {
+            LOG.info("[Migrate Config] Did not find any Cluster Profile. Possibly, user just have configured plugin settings and haven't define any elastic agent profiles.");
+            String newClusterId = UUID.randomUUID().toString();
+            LOG.info("[Migrate Config] Migrating existing plugin settings to new cluster profile '{}'", newClusterId);
+            ClusterProfile clusterProfile = new ClusterProfile(newClusterId, Constants.PLUGIN_ID, pluginSettings);
+
+            return getGoPluginApiResponse(pluginSettings, Arrays.asList(clusterProfile), existingElasticAgentProfiles);
         }
 
-        LOG.info("[Migrate Config] No defined cluster profiles found. Running migrations..");
-        String defaultClusterId = UUID.randomUUID().toString();
-        ClusterProfile clusterProfile = new ClusterProfile(defaultClusterId, Constants.PLUGIN_ID, pluginSettings);
-        existingElasticAgentProfiles.forEach(elasticAgentProfile -> {
-            elasticAgentProfile.setClusterProfileId(defaultClusterId);
-        });
+        LOG.info("[Migrate Config] Checking to perform migrations on Cluster Profiles '{}'.", existingClusterProfiles.stream().map(ClusterProfile::getId).collect(Collectors.toList()));
 
-        MigrateConfigurationRequest migrateConfigurationRequest = new MigrateConfigurationRequest();
-        migrateConfigurationRequest.setPluginSettings(pluginSettings);
-        migrateConfigurationRequest.setClusterProfiles(Arrays.asList(clusterProfile));
-        migrateConfigurationRequest.setElasticAgentProfiles(existingElasticAgentProfiles);
+        for (ClusterProfile clusterProfile : existingClusterProfiles) {
+            List<ElasticAgentProfile> associatedElasticAgentProfiles = findAssociatedElasticAgentProfiles(clusterProfile, existingElasticAgentProfiles);
+            if (associatedElasticAgentProfiles.size() == 0) {
+                LOG.info("[Migrate Config] Skipping migration for the cluster '{}' as no Elastic Agent Profiles are associated with it.", clusterProfile.getId());
+                continue;
+            }
+
+            if (!arePluginSettingsConfigured(clusterProfile.getClusterProfileProperties())) {
+                List<String> associatedProfileIds = associatedElasticAgentProfiles.stream().map(ElasticAgentProfile::getId).collect(Collectors.toList());
+                LOG.info("[Migrate Config] Found an empty cluster profile '{}' associated with '{}' elastic agent profiles.", clusterProfile.getId(), associatedProfileIds);
+                migrateConfigForCluster(pluginSettings, associatedElasticAgentProfiles, clusterProfile);
+            } else {
+                LOG.info("[Migrate Config] Skipping migration for the cluster '{}' as cluster has already been configured.", clusterProfile.getId());
+            }
+        }
 
         return new DefaultGoPluginApiResponse(200, migrateConfigurationRequest.toJSON());
+    }
+
+    //this is responsible to copy over plugin settings configurations to cluster profile and if required rename no op cluster
+    private void migrateConfigForCluster(PluginSettings pluginSettings, List<ElasticAgentProfile> associatedElasticAgentProfiles, ClusterProfile clusterProfile) {
+        LOG.info("[Migrate Config] Coping over existing plugin settings configurations to '{}' cluster profile.", clusterProfile.getId());
+        clusterProfile.setClusterProfileProperties(pluginSettings);
+
+        if (clusterProfile.getId().equals(String.format("no-op-cluster-for-%s", Constants.PLUGIN_ID))) {
+            String newClusterId = UUID.randomUUID().toString();
+            LOG.info("[Migrate Config] Renaming dummy cluster profile from '{}' to '{}'.", clusterProfile.getId(), newClusterId);
+            clusterProfile.setId(newClusterId);
+
+            LOG.info("[Migrate Config] Changing all elastic agent profiles to point to '{}' cluster profile.", clusterProfile.getId());
+            associatedElasticAgentProfiles.forEach(elasticAgentProfile -> elasticAgentProfile.setClusterProfileId(newClusterId));
+        }
+    }
+
+    private List<ElasticAgentProfile> findAssociatedElasticAgentProfiles(ClusterProfile clusterProfile, List<ElasticAgentProfile> elasticAgentProfiles) {
+        return elasticAgentProfiles.stream().filter(profile -> Objects.equals(profile.getClusterProfileId(), clusterProfile.getId())).collect(Collectors.toList());
+    }
+
+    private GoPluginApiResponse getGoPluginApiResponse(PluginSettings pluginSettings, List<ClusterProfile> clusterProfiles, List<ElasticAgentProfile> elasticAgentProfiles) {
+        MigrateConfigurationRequest response = new MigrateConfigurationRequest();
+
+        response.setPluginSettings(pluginSettings);
+        response.setClusterProfiles(clusterProfiles);
+        response.setElasticAgentProfiles(elasticAgentProfiles);
+
+        return new DefaultGoPluginApiResponse(200, response.toJSON());
     }
 
     private boolean arePluginSettingsConfigured(PluginSettings pluginSettings) {

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/MigrateConfigurationRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/MigrateConfigurationRequestExecutorTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 public class MigrateConfigurationRequestExecutorTest {
@@ -38,6 +39,7 @@ public class MigrateConfigurationRequestExecutorTest {
     private PluginSettings pluginSettings;
     private ClusterProfile clusterProfile;
     private ElasticAgentProfile elasticAgentProfile;
+    private HashMap<String, String> properties;
 
     @Before
     public void setUp() throws Exception {
@@ -54,7 +56,7 @@ public class MigrateConfigurationRequestExecutorTest {
         elasticAgentProfile.setId("profile_id");
         elasticAgentProfile.setPluginId(Constants.PLUGIN_ID);
         elasticAgentProfile.setClusterProfileId("cluster_profile_id");
-        HashMap<String, String> properties = new HashMap<>();
+        properties = new HashMap<>();
         properties.put("some_key", "some_value");
         properties.put("some_key2", "some_value2");
         elasticAgentProfile.setProperties(properties);
@@ -89,8 +91,57 @@ public class MigrateConfigurationRequestExecutorTest {
     }
 
     @Test
-    public void shouldDefineANewClusterProfileFromPluginSettings() throws Exception {
-        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Collections.emptyList(), Arrays.asList(elasticAgentProfile));
+    public void shouldPopulateNoOpClusterProfileWithPluginSettingsConfigurations() throws Exception {
+        ClusterProfile emptyClusterProfile = new ClusterProfile(String.format("no-op-cluster-for-%s", Constants.PLUGIN_ID), Constants.PLUGIN_ID, new PluginSettings());
+        elasticAgentProfile.setClusterProfileId(emptyClusterProfile.getId());
+        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Arrays.asList(emptyClusterProfile), Arrays.asList(elasticAgentProfile));
+        MigrateConfigurationRequestExecutor executor = new MigrateConfigurationRequestExecutor(request);
+
+        GoPluginApiResponse response = executor.execute();
+
+        MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
+
+        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        List<ClusterProfile> actual = responseObject.getClusterProfiles();
+        ClusterProfile actualClusterProfile = actual.get(0);
+
+        assertThat(actualClusterProfile.getId(), is(not(String.format("no-op-cluster-for-%s", Constants.PLUGIN_ID))));
+        this.clusterProfile.setId(actualClusterProfile.getId());
+
+        assertThat(actual, is(Arrays.asList(this.clusterProfile)));
+        assertThat(responseObject.getElasticAgentProfiles(), is(Arrays.asList(elasticAgentProfile)));
+
+        assertThat(elasticAgentProfile.getClusterProfileId(), is(actualClusterProfile.getId()));
+    }
+
+    @Test
+    public void shouldPopulateNoOpClusterProfileWithPluginSettingsConfigurations_WithoutChangingClusterProfileIdIfItsNotNoOp() throws Exception {
+        String clusterProfileId = "i-renamed-no-op-cluster-to-something-else";
+        ClusterProfile emptyClusterProfile = new ClusterProfile(clusterProfileId, Constants.PLUGIN_ID, new PluginSettings());
+        elasticAgentProfile.setClusterProfileId(emptyClusterProfile.getId());
+        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Arrays.asList(emptyClusterProfile), Arrays.asList(elasticAgentProfile));
+        MigrateConfigurationRequestExecutor executor = new MigrateConfigurationRequestExecutor(request);
+
+        GoPluginApiResponse response = executor.execute();
+
+        MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
+
+        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        List<ClusterProfile> actual = responseObject.getClusterProfiles();
+        ClusterProfile actualClusterProfile = actual.get(0);
+
+        assertThat(actualClusterProfile.getId(), is(clusterProfileId));
+        this.clusterProfile.setId(actualClusterProfile.getId());
+
+        assertThat(actual, is(Arrays.asList(this.clusterProfile)));
+        assertThat(responseObject.getElasticAgentProfiles(), is(Arrays.asList(elasticAgentProfile)));
+
+        assertThat(elasticAgentProfile.getClusterProfileId(), is(clusterProfileId));
+    }
+
+    @Test
+    public void shouldMigratePluginSettingsToClusterProfile_WhenNoElasticAgentProfilesAreConfigured() throws Exception {
+        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Collections.emptyList(), Collections.emptyList());
         MigrateConfigurationRequestExecutor executor = new MigrateConfigurationRequestExecutor(request);
 
         GoPluginApiResponse response = executor.execute();
@@ -103,21 +154,103 @@ public class MigrateConfigurationRequestExecutorTest {
         this.clusterProfile.setId(actualClusterProfile.getId());
 
         assertThat(actual, is(Arrays.asList(this.clusterProfile)));
-        assertThat(responseObject.getElasticAgentProfiles(), is(Arrays.asList(elasticAgentProfile)));
+        assertThat(responseObject.getElasticAgentProfiles(), is(Collections.emptyList()));
     }
 
     @Test
-    public void shouldAssociateExistingElasticAgentProfilesWithNewlyDefinedClusterProfile() throws Exception {
-        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Collections.emptyList(), Arrays.asList(elasticAgentProfile));
+    public void ShouldMigrateEmptyClusterProfiles_WhenMultipleEmptyClusterProfilesExists() throws Exception {
+        ClusterProfile emptyCluster1 = new ClusterProfile("cluster_profile_1", Constants.PLUGIN_ID, new PluginSettings());
+        ClusterProfile emptyCluster2 = new ClusterProfile("cluster_profile_2", Constants.PLUGIN_ID, new PluginSettings());
+
+        ElasticAgentProfile elasticAgentProfile1 = new ElasticAgentProfile();
+        elasticAgentProfile1.setId("profile_id_1");
+        elasticAgentProfile1.setPluginId(Constants.PLUGIN_ID);
+        elasticAgentProfile1.setClusterProfileId(emptyCluster1.getId());
+
+        ElasticAgentProfile elasticAgentProfile2 = new ElasticAgentProfile();
+        elasticAgentProfile2.setId("profile_id_2");
+        elasticAgentProfile2.setPluginId(Constants.PLUGIN_ID);
+        elasticAgentProfile2.setClusterProfileId(emptyCluster2.getId());
+
+        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Arrays.asList(emptyCluster1, emptyCluster2), Arrays.asList(elasticAgentProfile1, elasticAgentProfile2));
         MigrateConfigurationRequestExecutor executor = new MigrateConfigurationRequestExecutor(request);
 
         GoPluginApiResponse response = executor.execute();
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        String newlyDefinedClusterId = responseObject.getClusterProfiles().get(0).getId();
-        elasticAgentProfile.setClusterProfileId(newlyDefinedClusterId);
+        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
 
-        assertThat(responseObject.getElasticAgentProfiles(), is(Arrays.asList(elasticAgentProfile)));
+        this.clusterProfile.setId(responseObject.getClusterProfiles().get(0).getId());
+        assertThat(responseObject.getClusterProfiles().get(0), is(clusterProfile));
+
+        this.clusterProfile.setId(responseObject.getClusterProfiles().get(1).getId());
+        assertThat(responseObject.getClusterProfiles().get(1), is(clusterProfile));
+
+        assertThat(responseObject.getElasticAgentProfiles().get(0).getClusterProfileId(), is(emptyCluster1.getId()));
+        assertThat(responseObject.getElasticAgentProfiles().get(1).getClusterProfileId(), is(emptyCluster2.getId()));
+    }
+
+    @Test
+    public void ShouldNotMigrateEmptyAndUnassociatedClusterProfiles() throws Exception {
+        ClusterProfile emptyCluster1 = new ClusterProfile("cluster_profile_1", Constants.PLUGIN_ID, new PluginSettings());
+        ClusterProfile emptyCluster2 = new ClusterProfile("cluster_profile_2", Constants.PLUGIN_ID, new PluginSettings());
+
+        ElasticAgentProfile elasticAgentProfile1 = new ElasticAgentProfile();
+        elasticAgentProfile1.setId("profile_id_1");
+        elasticAgentProfile1.setPluginId(Constants.PLUGIN_ID);
+        elasticAgentProfile1.setClusterProfileId(emptyCluster1.getId());
+
+        ElasticAgentProfile elasticAgentProfile2 = new ElasticAgentProfile();
+        elasticAgentProfile2.setId("profile_id_2");
+        elasticAgentProfile2.setPluginId(Constants.PLUGIN_ID);
+        elasticAgentProfile2.setClusterProfileId(emptyCluster1.getId());
+
+        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Arrays.asList(emptyCluster1, emptyCluster2), Arrays.asList(elasticAgentProfile1, elasticAgentProfile2));
+        MigrateConfigurationRequestExecutor executor = new MigrateConfigurationRequestExecutor(request);
+
+        GoPluginApiResponse response = executor.execute();
+
+        MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
+
+        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+
+        this.clusterProfile.setId(responseObject.getClusterProfiles().get(0).getId());
+        assertThat(responseObject.getClusterProfiles().get(0), is(clusterProfile));
+
+        //verify cluster is empty.. not migrated
+        assertThat(responseObject.getClusterProfiles().get(1), is(emptyCluster2));
+
+        assertThat(responseObject.getElasticAgentProfiles().get(0).getClusterProfileId(), is(emptyCluster1.getId()));
+        assertThat(responseObject.getElasticAgentProfiles().get(1).getClusterProfileId(), is(emptyCluster1.getId()));
+    }
+
+    @Test
+    public void shouldNotMigrateConfigWhenMultipleClusterProfilesAreAlreadyMigrated() throws Exception {
+        ClusterProfile cluster1 = new ClusterProfile("cluster_profile_1", Constants.PLUGIN_ID, pluginSettings);
+        ClusterProfile cluster2 = new ClusterProfile("cluster_profile_2", Constants.PLUGIN_ID, pluginSettings);
+
+        ElasticAgentProfile elasticAgentProfile1 = new ElasticAgentProfile();
+        elasticAgentProfile1.setId("profile_id_1");
+        elasticAgentProfile1.setPluginId(Constants.PLUGIN_ID);
+        elasticAgentProfile1.setClusterProfileId(cluster1.getId());
+
+        ElasticAgentProfile elasticAgentProfile2 = new ElasticAgentProfile();
+        elasticAgentProfile2.setId("profile_id_2");
+        elasticAgentProfile2.setPluginId(Constants.PLUGIN_ID);
+        elasticAgentProfile2.setClusterProfileId(cluster2.getId());
+
+        MigrateConfigurationRequest request = new MigrateConfigurationRequest(pluginSettings, Arrays.asList(cluster1, cluster2), Arrays.asList(elasticAgentProfile1, elasticAgentProfile2));
+        MigrateConfigurationRequestExecutor executor = new MigrateConfigurationRequestExecutor(request);
+
+        GoPluginApiResponse response = executor.execute();
+
+        MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
+
+        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+
+        assertThat(responseObject.getClusterProfiles(), is(Arrays.asList(cluster1, cluster2)));
+
+        assertThat(responseObject.getElasticAgentProfiles(), is(Arrays.asList(elasticAgentProfile1, elasticAgentProfile2)));
     }
 }


### PR DESCRIPTION
Scenarios:

1. When no plugin settings are configured.
=> Do not migrate.

2. When plugin settings are configured and
   no cluster profiles and elastic agent profiles are defined.
=> Migrate plugin settings configurations to a default
   cluster.

3. When an empty cluster profile is defined; And is referenced from
   elastic agent profiles.
=> Migrate plugin settings to the empty cluster profile.
   And, if the cluster profile has the no-op cluster profile id,
   then rename the cluster-profile to a new UUID, and fix all the
   elastic agent profile references.

4. When an empty cluster profile is defined; And is not referenced
   from any elastic agent profiles.
=> Do not migrate such cluster profiles.