### PR TITLE
Show plugin messages in job console log

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/AgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/AgentInstances.java
@@ -29,11 +29,11 @@ public interface AgentInstances<T> {
      * <p>
      * So that instances created are auto-registered with the server, the agent instance MUST have an
      * <code>autoregister.properties</code> file.
-     *
      * @param request   the request object
      * @param pluginRequest  the plugin request object
+     * @param consoleLogAppender appender for console log
      */
-    T create(CreateAgentRequest request, PluginRequest pluginRequest) throws Exception;
+    T create(CreateAgentRequest request, PluginRequest pluginRequest, ConsoleLogAppender consoleLogAppender) throws Exception;
 
     /**
      * This message is sent when the plugin needs to terminate the agent instance.

--- a/src/main/java/cd/go/contrib/elasticagents/docker/ConsoleLogAppender.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/ConsoleLogAppender.java
@@ -1,0 +1,6 @@
+package cd.go.contrib.elasticagents.docker;
+
+import java.util.function.Consumer;
+
+public interface ConsoleLogAppender extends Consumer<String> {
+}

--- a/src/main/java/cd/go/contrib/elasticagents/docker/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/Constants.java
@@ -30,6 +30,7 @@ public interface Constants {
     // The extension point API version that this plugin understands
     String PROCESSOR_API_VERSION = "1.0";
     String EXTENSION_API_VERSION = "5.0";
+    String CONSOLE_LOG_API_VERSION = "1.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(EXTENSION_API_VERSION));
@@ -40,6 +41,7 @@ public interface Constants {
     String REQUEST_SERVER_DELETE_AGENT = REQUEST_SERVER_PREFIX + ".elastic-agents.delete-agents";
     String REQUEST_SERVER_LIST_AGENTS = REQUEST_SERVER_PREFIX + ".elastic-agents.list-agents";
     String REQUEST_SERVER_SERVER_HEALTH_ADD_MESSAGES = REQUEST_SERVER_PREFIX + ".server-health.add-messages";
+    String REQUEST_SERVER_APPEND_TO_CONSOLE_LOG = REQUEST_SERVER_PREFIX + ".console-log.append";
 
     // internal use only
     String CREATED_BY_LABEL_KEY = "Elastic-Agent-Created-By";

--- a/src/main/java/cd/go/contrib/elasticagents/docker/PluginRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/PluginRequest.java
@@ -107,7 +107,7 @@ public class PluginRequest {
         GoApiResponse response = accessor.submit(request);
 
         if (response.responseCode() != 200) {
-            LOG.error("Failed to append console log for " + jobIdentifier.represent() + " with text: " + text);
+            LOG.error("Failed to append to console log for " + jobIdentifier.represent() + " with text: " + text);
         }
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/docker/ServerRequestFailedException.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/ServerRequestFailedException.java
@@ -20,7 +20,7 @@ import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 
 import static java.lang.String.format;
 
-public class ServerRequestFailedException extends Exception {
+public class ServerRequestFailedException extends RuntimeException {
 
     private ServerRequestFailedException(GoApiResponse response, String request) {
         super(format(
@@ -43,5 +43,9 @@ public class ServerRequestFailedException extends Exception {
 
     public static ServerRequestFailedException getPluginSettings(GoApiResponse response) {
         return new ServerRequestFailedException(response, "get plugin settings");
+    }
+
+    public static ServerRequestFailedException appendToConsoleLog(GoApiResponse response) {
+        return new ServerRequestFailedException(response, "append to console log");
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutor.java
@@ -20,6 +20,7 @@ import cd.go.contrib.elasticagents.docker.*;
 import cd.go.contrib.elasticagents.docker.requests.CreateAgentRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 import org.joda.time.format.DateTimeFormat;
@@ -47,7 +48,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
             pluginRequest.appendToConsoleLog(request.jobIdentifier(), message);
         };
 
-        consoleLogAppender.accept(String.format("Received request to create a container of %s", request.dockerImage()));
+        consoleLogAppender.accept(String.format("Received request to create a container of %s at %s", request.dockerImage(), new DateTime().toString("yyyy-MM-dd HH:mm:ss ZZ")));
 
         try {
             agentInstances.create(request, pluginRequest, consoleLogAppender);

--- a/src/main/java/cd/go/contrib/elasticagents/docker/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/requests/CreateAgentRequest.java
@@ -23,12 +23,9 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Properties;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -59,7 +56,7 @@ public class CreateAgentRequest {
         this.clusterProfileProperties = clusterProfileProperties;
     }
 
-    public String autoRegisterKey() {
+    String autoRegisterKey() {
         return autoRegisterKey;
     }
 
@@ -87,37 +84,6 @@ public class CreateAgentRequest {
         return new CreateAgentRequestExecutor(this, agentInstances, pluginRequest);
     }
 
-    public Properties autoregisterProperties(String elasticAgentId) {
-        Properties properties = new Properties();
-
-        if (isNotBlank(autoRegisterKey)) {
-            properties.put("agent.auto.register.key", autoRegisterKey);
-        }
-
-        if (isNotBlank(environment)) {
-            properties.put("agent.auto.register.environments", environment);
-        }
-
-        properties.put("agent.auto.register.elasticAgent.agentId", elasticAgentId);
-        properties.put("agent.auto.register.elasticAgent.pluginId", Constants.PLUGIN_ID);
-
-        return properties;
-    }
-
-    public String autoregisterPropertiesAsString(String elasticAgentId) {
-        Properties properties = autoregisterProperties(elasticAgentId);
-
-        StringWriter writer = new StringWriter();
-
-        try {
-            properties.store(writer, "");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        return writer.toString();
-    }
-
     public Collection<String> autoregisterPropertiesAsEnvironmentVars(String elasticAgentId) {
         ArrayList<String> vars = new ArrayList<>();
         if (isNotBlank(autoRegisterKey)) {
@@ -129,5 +95,9 @@ public class CreateAgentRequest {
         vars.add("GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID=" + elasticAgentId);
         vars.add("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID=" + Constants.PLUGIN_ID);
         return vars;
+    }
+
+    public String dockerImage() {
+        return properties().get("Image");
     }
 }

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -32,7 +32,7 @@
 
 	<div class="form_item_block">
 		<label>Go Server URL (this is passed to the agents, so don't use <code>localhost</code>):<span
-			class='asterix'>*</span></label>
+			class='asterix'> *</span></label>
 		<input type="text" ng-model="go_server_url" ng-required="true" placeholder="https://ipaddress:8154/go"/>
 		<span class="form_error" ng-show="GOINPUTNAME[go_server_url].$error.server">{{GOINPUTNAME[go_server_url].$error.server}}</span>
 	</div>
@@ -49,19 +49,19 @@
 		</div>
 
 		<div class="form_item_block">
-			<label>Agent auto-register Timeout (in minutes):<span class='asterix'>*</span></label>
+			<label>Agent auto-register Timeout (in minutes):<span class='asterix'> *</span></label>
 			<input type="text" ng-model="auto_register_timeout" ng-required="true"/>
 			<span class="form_error" ng-show="GOINPUTNAME[auto_register_timeout].$error.server">{{GOINPUTNAME[auto_register_timeout].$error.server}}</span>
 		</div>
 
 		<div class="form_item_block">
-			<label>Maximum docker containers to run at any given point in time:<span class='asterix'>*</span></label>
+			<label>Maximum docker containers to run at any given point in time:<span class='asterix'> *</span></label>
 			<input type="text" ng-model="max_docker_containers" ng-required="true"/>
 			<span class="form_error" ng-show="GOINPUTNAME[max_docker_containers].$error.server">{{GOINPUTNAME[max_docker_containers].$error.server}}</span>
 		</div>
 
 		<div class="form_item_block">
-			<input type="checkbox" ng-model="pull_on_container_create" id="pull_on_container_create" ng-true-value="true" ng-false-value="false"/>
+			<input type="checkbox" ng-model="pull_on_container_create" id="pull_on_container_create" ng-init="pull_on_container_create = pull_on_container_create || false" ng-true-value="true" ng-false-value="false"/>
 			<label for="pull_on_container_create">Always pull image before creating the container</label>
 			<span class="form_error" ng-show="GOINPUTNAME[pull_on_container_create].$error.server">{{GOINPUTNAME[pull_on_container_create].$error.server}}</span>
 		</div>
@@ -69,8 +69,8 @@
 	<fieldset>
 		<legend>Docker client configuration</legend>
 		<div class="form_item_block">
-			<label>Docker URI:<span class='asterix'>*</span></label>
-			<input type="text" ng-model="docker_uri" ng-required="true"/>
+			<label>Docker URI:<span class='asterix'> *</span></label>
+			<input type="text" ng-model="docker_uri" ng-required="true" placeholder="For Docker running locally, try unix:///var/run/docker.sock"/>
 			<span class="form_error" ng-show="GOINPUTNAME[docker_uri].$error.server">{{GOINPUTNAME[docker_uri].$error.server}}</span>
 		</div>
 
@@ -96,7 +96,7 @@
 	<fieldset>
 		<legend>Docker registry settings</legend>
 		<div class="form_item_block">
-			<input type="checkbox" ng-model="enable_private_registry_authentication" id="enable_private_registry_authentication" ng-true-value="true" ng-false-value="false"/>
+			<input type="checkbox" ng-model="enable_private_registry_authentication" id="enable_private_registry_authentication" ng-init="enable_private_registry_authentication = enable_private_registry_authentication || false" ng-true-value="true" ng-false-value="false"/>
 			<label for="enable_private_registry_authentication">Use Private Registry</label>
 			<span class="form_error" ng-show="GOINPUTNAME[enable_private_registry_authentication].$error.server">{{GOINPUTNAME[enable_private_registry_authentication].$error.server}}</span>
 		</div>

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -39,7 +39,7 @@
 
     <div class="form_item_block">
         <label ng-class="{'is-invalid-label': GOINPUTNAME[Image].$error.server}">Docker image:<span class='asterix'>*</span></label>
-        <input ng-class="{'is-invalid-input': GOINPUTNAME[Image].$error.server}" type="text" ng-model="Image" ng-required="true" placeholder="alpine:latest"/>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[Image].$error.server}" type="text" ng-model="Image" ng-required="true" placeholder="gocd/gocd-agent-alpine-3.9:v19.3.0"/>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Image].$error.server}" ng-show="GOINPUTNAME[Image].$error.server">{{GOINPUTNAME[Image].$error.server}}</span>
     </div>
 
@@ -53,14 +53,14 @@
     </div>
 
     <div class="form_item_block">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[Command].$error.server}">Docker Command: <small>(Enter one parameter per line)</small></label>
-        <textarea ng-class="{'is-invalid-input': GOINPUTNAME[Command].$error.server}" type="text" ng-model="Command" ng-required="true" rows="7" placeholder="ls&#x000A;-al&#x000A;/usr/bin"></textarea>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[Command].$error.server}">Docker Command: <small>(Enter one parameter per line. Leave empty to use image's default command)</small></label>
+        <textarea ng-class="{'is-invalid-input': GOINPUTNAME[Command].$error.server}" type="text" ng-model="Command" ng-required="true" rows="7" placeholder="/docker-entrypoint.sh&#x000A;param1&#x000A;param2"></textarea>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Command].$error.server}" ng-show="GOINPUTNAME[Command].$error.server">{{GOINPUTNAME[Command].$error.server}}</span>
     </div>
 
     <div class="form_item_block">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[Environment].$error.server}">Environment Variables <small>(Enter one variable per line)</small></label>
-        <textarea ng-class="{'is-invalid-input': GOINPUTNAME[Environment].$error.server}" type="text" ng-model="Environment" ng-required="true" rows="7" placeholder="JAVA_HOME=/opt/java&#x000A;MAVEN_HOME=/opt/maven"></textarea>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[Environment].$error.server}">Extra environment Variables <small>(Enter one variable per line)</small></label>
+        <textarea ng-class="{'is-invalid-input': GOINPUTNAME[Environment].$error.server}" type="text" ng-model="Environment" ng-required="true" rows="7" placeholder="MY_ENV_VAR1=value1&#x000A;MY_ENV_VAR2=value2"></textarea>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Environment].$error.server}" ng-show="GOINPUTNAME[Environment].$error.server">{{GOINPUTNAME[Environment].$error.server}}</span>
     </div>
 
@@ -96,9 +96,7 @@
 
     <div class="row">
         <div class="columns end">
-            <label ng-class="{'is-invalid-label': GOINPUTNAME[Hosts].$error.server}">Host entries
-                <small>(Enter one host entry per line)</small>
-            </label>
+            <label ng-class="{'is-invalid-label': GOINPUTNAME[Hosts].$error.server}">Extra Host entries <small>(Enter one host entry per line)</small></label>
             <textarea ng-class="{'is-invalid-input': GOINPUTNAME[Hosts].$error.server}" type="text" ng-model="Hosts" ng-required="true" rows="7"></textarea>
             <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Hosts].$error.server}" ng-show="GOINPUTNAME[Hosts].$error.server">{{GOINPUTNAME[Hosts].$error.server}}</span>
             <label class="form-help-content">

--- a/src/test/java/cd/go/contrib/elasticagents/docker/PluginRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/PluginRequestTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagents.docker;
+
+import cd.go.contrib.elasticagents.docker.models.JobIdentifier;
+import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
+import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PluginRequestTest {
+    @Test
+    public void shouldNotThrowAnExceptionIfConsoleLogAppenderCallFails() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("p1", 1L, "l1", "s1", "1", "j1", 1L);
+
+        GoApplicationAccessor accessor = mock(GoApplicationAccessor.class);
+        when(accessor.submit(any())).thenReturn(DefaultGoApiResponse.badRequest("Something went wrong"));
+
+        final PluginRequest pluginRequest = new PluginRequest(accessor);
+        pluginRequest.appendToConsoleLog(jobIdentifier, "text1");
+    }
+}

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,50 @@
 package cd.go.contrib.elasticagents.docker.executors;
 
 import cd.go.contrib.elasticagents.docker.*;
+import cd.go.contrib.elasticagents.docker.models.JobIdentifier;
 import cd.go.contrib.elasticagents.docker.requests.CreateAgentRequest;
 import org.junit.Test;
 
+import java.util.HashMap;
+
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class CreateAgentRequestExecutorTest {
     @Test
     public void shouldAskDockerContainersToCreateAnAgent() throws Exception {
-        CreateAgentRequest request = new CreateAgentRequest();
+        final HashMap<String, String> elasticAgentProfileProperties = new HashMap<>();
+        elasticAgentProfileProperties.put("Image", "image1");
+        final JobIdentifier jobIdentifier = new JobIdentifier("p1", 1L, "l1", "s1", "1", "j1", 1L);
+        CreateAgentRequest request = new CreateAgentRequest("key1", elasticAgentProfileProperties, "env1", jobIdentifier, new HashMap<>());
+
         AgentInstances<DockerContainer> agentInstances = mock(DockerContainers.class);
         PluginRequest pluginRequest = mock(PluginRequest.class);
         new CreateAgentRequestExecutor(request, agentInstances, pluginRequest).execute();
 
-        verify(agentInstances).create(request, pluginRequest);
+        verify(agentInstances).create(eq(request), eq(pluginRequest), any(ConsoleLogAppender.class));
+        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Received request to create a container of image1"));
+    }
+
+    @Test
+    public void shouldLogErrorMessageToConsoleIfAgentCreateFails() throws Exception {
+        final HashMap<String, String> elasticAgentProfileProperties = new HashMap<>();
+        elasticAgentProfileProperties.put("Image", "image1");
+        final JobIdentifier jobIdentifier = new JobIdentifier("p1", 1L, "l1", "s1", "1", "j1", 1L);
+        CreateAgentRequest request = new CreateAgentRequest("key1", elasticAgentProfileProperties, "env1", jobIdentifier, new HashMap<>());
+
+        AgentInstances<DockerContainer> agentInstances = mock(DockerContainers.class);
+        PluginRequest pluginRequest = mock(PluginRequest.class);
+        when(agentInstances.create(eq(request), eq(pluginRequest), any(ConsoleLogAppender.class))).thenThrow(new RuntimeException("Ouch!"));
+
+        try {
+            new CreateAgentRequestExecutor(request, agentInstances, pluginRequest).execute();
+            fail("Should have thrown an exception");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Received request to create a container of image1"));
+        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Failed while creating container: Ouch"));
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/CreateAgentRequestExecutorTest.java
@@ -39,7 +39,7 @@ public class CreateAgentRequestExecutorTest {
         new CreateAgentRequestExecutor(request, agentInstances, pluginRequest).execute();
 
         verify(agentInstances).create(eq(request), eq(pluginRequest), any(ConsoleLogAppender.class));
-        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Received request to create a container of image1"));
+        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Received request to create a container of image1 at "));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class CreateAgentRequestExecutorTest {
             // expected
         }
 
-        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Received request to create a container of image1"));
+        verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Received request to create a container of image1 at "));
         verify(pluginRequest).appendToConsoleLog(eq(jobIdentifier), contains("Failed while creating container: Ouch"));
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ServerPingRequestExecutorTest.java
@@ -95,7 +95,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("Image", "alpine");
         properties.put("Command", "/bin/sleep\n5");
-        DockerContainer container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier(), createClusterProfiles()), pluginRequest);
+        DockerContainer container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier(), createClusterProfiles()), pluginRequest, mock(ConsoleLogAppender.class));
         containers.add(container.name());
 
         HashMap<String, DockerContainers> dockerContainers = new HashMap<String, DockerContainers>() {{

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -48,7 +48,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         properties.put("Command", "/bin/sleep\n5");
         ClusterProfileProperties clusterProfiles = createClusterProfiles();
         PluginRequest pluginRequest = mock(PluginRequest.class);
-        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, jobIdentifier, clusterProfiles), pluginRequest);
+        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, jobIdentifier, clusterProfiles), pluginRequest, mock(ConsoleLogAppender.class));
         containers.add(instance.name());
     }
 


### PR DESCRIPTION
See https://github.com/gocd/gocd/pull/6299

This is not a comprehensive change, which sets up messages for all scenarios. It just shows how this _can_ be used.

### Todo:

- [ ] Consider versioning. What happens if you use a plugin with this change, with an older server? I mean, it'll not throw, but might need @GaneshSPatil or @bdpiparva's help to understand if capabilities can be used / should be used to check, before sending these messages.

### How does it look?

<img width="1440" alt="2019_05_16_21-30-48" src="https://user-images.githubusercontent.com/172235/57899879-bc074d00-782c-11e9-91f6-42978565e050.png">
